### PR TITLE
fix: fixing path to migrations assembly

### DIFF
--- a/src/Ambev.DeveloperEvaluation.ORM/DefaultContext.cs
+++ b/src/Ambev.DeveloperEvaluation.ORM/DefaultContext.cs
@@ -34,7 +34,7 @@ public class YourDbContextFactory : IDesignTimeDbContextFactory<DefaultContext>
 
         builder.UseNpgsql(
                connectionString,
-               b => b.MigrationsAssembly("Ambev.DeveloperEvaluation.WebApi")
+               b => b.MigrationsAssembly("Ambev.DeveloperEvaluation.ORM")
         );
 
         return new DefaultContext(builder.Options);


### PR DESCRIPTION
[Resumo gerado pelo copilot]
This pull request updates the `CreateDbContext` method in the `DefaultContext` class to correctly reference the migrations assembly. The change ensures that the assembly name aligns with the project structure.

Database configuration update:

* [`src/Ambev.DeveloperEvaluation.ORM/DefaultContext.cs`](diffhunk://#diff-17f9819b37a3744f7f18b3a834658ec2df73c6176d5452c576789bb3d66063dbL37-R37): Updated the `UseNpgsql` method to reference the `Ambev.DeveloperEvaluation.ORM` assembly instead of `Ambev.DeveloperEvaluation.WebApi` for migrations.